### PR TITLE
ACK/NACK reliability fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,11 @@ sourceSets {
 			srcDirs = ['src']
 		}
 	}
+	test {
+		java {
+			srcDirs = ['test']
+		}
+	}
 }
 
 repositories {
@@ -56,6 +61,7 @@ dependencies {
 	compile fileTree(dir: dlDepsDir, include: '*.jar')
 	compile group: 'io.netty', name: 'netty-all', version: '4.1.22.Final'
 	compile group: 'it.unimi.dsi', name: 'fastutil', version: '8.1.1'
+	testCompile group: 'junit', name: 'junit-dep', version: '4.8.1'
 }
 
 

--- a/src/raknetserver/RakNetServer.java
+++ b/src/raknetserver/RakNetServer.java
@@ -24,7 +24,6 @@ import raknetserver.pipeline.raknet.RakNetPacketDecoder;
 import raknetserver.pipeline.raknet.RakNetPacketEncoder;
 import raknetserver.pipeline.raknet.RakNetPacketReliabilityHandler;
 import raknetserver.utils.Constants;
-import raknetserver.utils.UINT;
 import udpserversocketchannel.channel.UdpServerChannel;
 
 public class RakNetServer {

--- a/src/raknetserver/RakNetServer.java
+++ b/src/raknetserver/RakNetServer.java
@@ -10,10 +10,10 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.handler.timeout.ReadTimeoutHandler;
-import raknetserver.pipeline.ecnapsulated.EncapsulatedPacketInboundOrderer;
-import raknetserver.pipeline.ecnapsulated.EncapsulatedPacketOutboundOrder;
-import raknetserver.pipeline.ecnapsulated.EncapsulatedPacketSplitter;
-import raknetserver.pipeline.ecnapsulated.EncapsulatedPacketUnsplitter;
+import raknetserver.pipeline.encapsulated.EncapsulatedPacketInboundOrderer;
+import raknetserver.pipeline.encapsulated.EncapsulatedPacketOutboundOrder;
+import raknetserver.pipeline.encapsulated.EncapsulatedPacketSplitter;
+import raknetserver.pipeline.encapsulated.EncapsulatedPacketUnsplitter;
 import raknetserver.pipeline.internal.InternalPacketDecoder;
 import raknetserver.pipeline.internal.InternalPacketEncoder;
 import raknetserver.pipeline.internal.InternalPacketReadHandler;
@@ -24,6 +24,7 @@ import raknetserver.pipeline.raknet.RakNetPacketDecoder;
 import raknetserver.pipeline.raknet.RakNetPacketEncoder;
 import raknetserver.pipeline.raknet.RakNetPacketReliabilityHandler;
 import raknetserver.utils.Constants;
+import raknetserver.utils.UINT;
 import udpserversocketchannel.channel.UdpServerChannel;
 
 public class RakNetServer {
@@ -59,7 +60,7 @@ public class RakNetServer {
 				.addLast("rns-rn-encoder", new RakNetPacketEncoder())
 				.addLast("rns-rn-decoder", new RakNetPacketDecoder())
 				.addLast("rns-rn-connect", new RakNetPacketConnectionEstablishHandler(pinghandler))
-				.addLast("rns-rn-reliability", new RakNetPacketReliabilityHandler())
+				.addLast("rns-rn-reliability", new RakNetPacketReliabilityHandler(channel))
 				.addLast("rns-e-ru", new EncapsulatedPacketUnsplitter())
 				.addLast("rns-e-ro", new EncapsulatedPacketInboundOrderer())
 				.addLast("rns-e-ws", new EncapsulatedPacketSplitter())

--- a/src/raknetserver/packet/raknet/RakNetReliability.java
+++ b/src/raknetserver/packet/raknet/RakNetReliability.java
@@ -8,6 +8,12 @@ public class RakNetReliability implements RakNetPacket {
 
 	public RakNetReliability() {
 	}
+	public RakNetReliability(int ... ids) {
+		entries = new REntry[ids.length];
+		for (int i = 0 ; i < ids.length ; i++) {
+			entries[i] = new REntry(ids[i]);
+		}
+	}
 
 	public RakNetReliability(int id) {
 		this(id, id);
@@ -35,9 +41,14 @@ public class RakNetReliability implements RakNetPacket {
 	public void encode(ByteBuf buf) {
 		buf.writeShort(entries.length);
 		for (REntry entry : entries) {
-			buf.writeBoolean(false);
-			buf.writeMediumLE(entry.idStart);
-			buf.writeMediumLE(entry.idFinish);
+			if (entry.idStart == entry.idFinish) {
+				buf.writeBoolean(true);
+				buf.writeMediumLE(entry.idStart);
+			} else {
+				buf.writeBoolean(false);
+				buf.writeMediumLE(entry.idStart);
+				buf.writeMediumLE(entry.idFinish);
+			}
 		}
 	}
 
@@ -60,6 +71,9 @@ public class RakNetReliability implements RakNetPacket {
 	public static class RakNetACK extends RakNetReliability {
 		public RakNetACK() {
 		}
+		public RakNetACK(int ... ids) {
+			super(ids);
+		}
 		public RakNetACK(int id) {
 			this(id, id);
 		}
@@ -69,6 +83,9 @@ public class RakNetReliability implements RakNetPacket {
 	}
 	public static class RakNetNACK extends RakNetReliability {
 		public RakNetNACK() {
+		}
+		public RakNetNACK(int ... ids) {
+			super(ids);
 		}
 		public RakNetNACK(int id) {
 			this(id, id);

--- a/src/raknetserver/packet/raknet/RakNetReliability.java
+++ b/src/raknetserver/packet/raknet/RakNetReliability.java
@@ -11,27 +11,30 @@ public class RakNetReliability implements RakNetPacket {
 
 	public RakNetReliability() {
 	}
-	public RakNetReliability(IntSortedSet ids) {
+	public RakNetReliability(IntSortedSet ids) { //TODO: dense format is broked
+		entries = new REntry[0];
+		if (ids.isEmpty()) {
+			return;
+		}
 		ArrayList<REntry> res = new ArrayList<>();
 		//lets make our sparse array of ids here
 		int startId = -1;
 		int endId = -1;
 		for(int i : ids) {
+			assert i >= 0;
 			if (startId == -1) {
 				startId = i; //new region
 				endId = i;
 			} else if (i == (endId + 1)) {
-				endId++; //continue region
+				endId = i; //continue region
 			} else {
 				res.add(new REntry(startId, endId));
 				startId = i; //new region
 				endId = i;
 			}
 		}
-		if (startId != -1) {
-			res.add(new REntry(startId, endId));
-		}
-		entries = res.toArray(new REntry[0]);
+		res.add(new REntry(startId, endId));
+		entries = res.toArray(entries);
 	}
 
 	public RakNetReliability(int id) {

--- a/src/raknetserver/packet/raknet/RakNetReliability.java
+++ b/src/raknetserver/packet/raknet/RakNetReliability.java
@@ -1,6 +1,9 @@
 package raknetserver.packet.raknet;
 
 import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
+
+import java.util.ArrayList;
 
 public class RakNetReliability implements RakNetPacket {
 
@@ -8,11 +11,27 @@ public class RakNetReliability implements RakNetPacket {
 
 	public RakNetReliability() {
 	}
-	public RakNetReliability(int ... ids) {
-		entries = new REntry[ids.length];
-		for (int i = 0 ; i < ids.length ; i++) {
-			entries[i] = new REntry(ids[i]);
+	public RakNetReliability(IntSortedSet ids) {
+		ArrayList<REntry> res = new ArrayList<>();
+		//lets make our sparse array of ids here
+		int startId = -1;
+		int endId = -1;
+		for(int i : ids) {
+			if (startId == -1) {
+				startId = i; //new region
+				endId = i;
+			} else if (i == (endId + 1)) {
+				endId++; //continue region
+			} else {
+				res.add(new REntry(startId, endId));
+				startId = i; //new region
+				endId = i;
+			}
 		}
+		if (startId != -1) {
+			res.add(new REntry(startId, endId));
+		}
+		entries = res.toArray(new REntry[0]);
 	}
 
 	public RakNetReliability(int id) {
@@ -71,7 +90,7 @@ public class RakNetReliability implements RakNetPacket {
 	public static class RakNetACK extends RakNetReliability {
 		public RakNetACK() {
 		}
-		public RakNetACK(int ... ids) {
+		public RakNetACK(IntSortedSet ids) {
 			super(ids);
 		}
 		public RakNetACK(int id) {
@@ -84,7 +103,7 @@ public class RakNetReliability implements RakNetPacket {
 	public static class RakNetNACK extends RakNetReliability {
 		public RakNetNACK() {
 		}
-		public RakNetNACK(int ... ids) {
+		public RakNetNACK(IntSortedSet ids) {
 			super(ids);
 		}
 		public RakNetNACK(int id) {

--- a/src/raknetserver/packet/raknet/RakNetReliability.java
+++ b/src/raknetserver/packet/raknet/RakNetReliability.java
@@ -1,39 +1,12 @@
 package raknetserver.packet.raknet;
 
 import io.netty.buffer.ByteBuf;
-import it.unimi.dsi.fastutil.ints.IntSortedSet;
-
-import java.util.ArrayList;
 
 public class RakNetReliability implements RakNetPacket {
 
 	private REntry[] entries;
 
 	public RakNetReliability() {
-	}
-	public RakNetReliability(IntSortedSet ids) {
-		entries = new REntry[0];
-		if (ids.isEmpty()) {
-			return;
-		}
-		ArrayList<REntry> res = new ArrayList<>();
-		int startId = -1;
-		int endId = -1;
-		for(int i : ids) {
-			assert i >= 0;
-			if (startId == -1) {
-				startId = i; //new region
-				endId = i;
-			} else if (i == (endId + 1)) {
-				endId = i; //continue region
-			} else {
-				res.add(new REntry(startId, endId));
-				startId = i; //new region
-				endId = i;
-			}
-		}
-		res.add(new REntry(startId, endId));
-		entries = res.toArray(entries);
 	}
 
 	public RakNetReliability(int id) {
@@ -92,9 +65,6 @@ public class RakNetReliability implements RakNetPacket {
 	public static class RakNetACK extends RakNetReliability {
 		public RakNetACK() {
 		}
-		public RakNetACK(IntSortedSet ids) {
-			super(ids);
-		}
 		public RakNetACK(int id) {
 			this(id, id);
 		}
@@ -104,9 +74,6 @@ public class RakNetReliability implements RakNetPacket {
 	}
 	public static class RakNetNACK extends RakNetReliability {
 		public RakNetNACK() {
-		}
-		public RakNetNACK(IntSortedSet ids) {
-			super(ids);
 		}
 		public RakNetNACK(int id) {
 			this(id, id);

--- a/src/raknetserver/packet/raknet/RakNetReliability.java
+++ b/src/raknetserver/packet/raknet/RakNetReliability.java
@@ -11,13 +11,12 @@ public class RakNetReliability implements RakNetPacket {
 
 	public RakNetReliability() {
 	}
-	public RakNetReliability(IntSortedSet ids) { //TODO: dense format is broked
+	public RakNetReliability(IntSortedSet ids) {
 		entries = new REntry[0];
 		if (ids.isEmpty()) {
 			return;
 		}
 		ArrayList<REntry> res = new ArrayList<>();
-		//lets make our sparse array of ids here
 		int startId = -1;
 		int endId = -1;
 		for(int i : ids) {

--- a/src/raknetserver/pipeline/encapsulated/EncapsulatedPacketInboundOrderer.java
+++ b/src/raknetserver/pipeline/encapsulated/EncapsulatedPacketInboundOrderer.java
@@ -44,7 +44,7 @@ public class EncapsulatedPacketInboundOrderer extends MessageToMessageDecoder<En
 					lastReceivedIndex = packet.getOrderIndex();
 					list.add(Unpooled.wrappedBuffer(packet.getData()));
 					packet = queue.remove(UINT.B3.plus(packet.getOrderIndex(), 1));
-				} while(packet != null);
+				} while (packet != null);
 			} else if (indexDiff > 1) { // future data goes in the queue
 				queue.put(packet.getOrderIndex(), packet);
 			}

--- a/src/raknetserver/pipeline/encapsulated/EncapsulatedPacketOutboundOrder.java
+++ b/src/raknetserver/pipeline/encapsulated/EncapsulatedPacketOutboundOrder.java
@@ -1,4 +1,4 @@
-package raknetserver.pipeline.ecnapsulated;
+package raknetserver.pipeline.encapsulated;
 
 import java.util.List;
 

--- a/src/raknetserver/pipeline/encapsulated/EncapsulatedPacketSplitter.java
+++ b/src/raknetserver/pipeline/encapsulated/EncapsulatedPacketSplitter.java
@@ -1,4 +1,4 @@
-package raknetserver.pipeline.ecnapsulated;
+package raknetserver.pipeline.encapsulated;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/raknetserver/pipeline/encapsulated/EncapsulatedPacketUnsplitter.java
+++ b/src/raknetserver/pipeline/encapsulated/EncapsulatedPacketUnsplitter.java
@@ -1,18 +1,18 @@
-package raknetserver.pipeline.ecnapsulated;
+package raknetserver.pipeline.encapsulated;
 
-import java.util.HashMap;
 import java.util.List;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import raknetserver.packet.EncapsulatedPacket;
 import raknetserver.utils.Constants;
 import raknetserver.utils.Utils;
 
 public class EncapsulatedPacketUnsplitter extends MessageToMessageDecoder<EncapsulatedPacket> {
 
-	private final HashMap<Integer, SplittedPacket> notFullPackets = new HashMap<>();
+	private final Int2ObjectOpenHashMap<SplittedPacket> notFullPackets = new Int2ObjectOpenHashMap<>();
 
 	@Override
 	protected void decode(ChannelHandlerContext ctx, EncapsulatedPacket packet, List<Object> list) throws Exception {

--- a/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
+++ b/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
@@ -7,8 +7,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.DecoderException;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import raknetserver.packet.EncapsulatedPacket;
 import raknetserver.packet.raknet.RakNetEncapsulatedData;
 import raknetserver.packet.raknet.RakNetPacket;

--- a/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
+++ b/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
@@ -125,8 +125,7 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 			if (sentPackets.size() > Constants.MAX_PACKET_LOSS) {
 				throw new DecoderException("Too big packet loss (unconfirmed sent packets)");
 			}
-			RakNetEncapsulatedData outPacket = new RakNetEncapsulatedData((EncapsulatedPacket) msg);
-			sendPacket(outPacket, promise);
+			sendPacket(new RakNetEncapsulatedData((EncapsulatedPacket) msg), promise);
 		} else {
 			ctx.writeAndFlush(msg, promise);
 		}

--- a/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
+++ b/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
@@ -7,10 +7,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.DecoderException;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.ints.IntSortedSet;
-import it.unimi.dsi.fastutil.ints.IntComparators;
 import raknetserver.packet.EncapsulatedPacket;
 import raknetserver.packet.raknet.RakNetEncapsulatedData;
 import raknetserver.packet.raknet.RakNetPacket;
@@ -22,13 +19,11 @@ import raknetserver.utils.PacketHandlerRegistry;
 import raknetserver.utils.UINT;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.IntPredicate;
 
 public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 
 	protected static final int WINDOW = 4096;
 	protected static final int HALF_WINDOW = WINDOW / 2;
-	protected static final int CONTROL_INTERVAL = 50; //millis
 	protected static final int RTT_FLOOR = 5; //millis
 
 	protected static final PacketHandlerRegistry<RakNetPacketReliabilityHandler, RakNetPacket> registry = new PacketHandlerRegistry<>();
@@ -39,11 +34,8 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 	}
 
 	protected final Channel channel;
-	protected final IntSortedSet nackSet = new IntRBTreeSet(IntComparators.NATURAL_COMPARATOR);
-	protected final IntSortedSet ackSet = new IntRBTreeSet(IntComparators.NATURAL_COMPARATOR);
 	protected final IntOpenHashSet handledSet = new IntOpenHashSet();
 	protected final Int2ObjectOpenHashMap<RakNetEncapsulatedData> sentPackets = new Int2ObjectOpenHashMap<>();
-	protected final IntPredicate removalPredicate = x -> !idWithinWindow(x);
 
 	protected int lastReceivedSeqId = 0;
 	protected int nextSendSeqId = 0;
@@ -51,17 +43,7 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 
 	public RakNetPacketReliabilityHandler(Channel channel) {
 		this.channel = channel;
-		startFlushTimer();
 		startResendTimer();
-	}
-
-	private void startFlushTimer() {
-		channel.eventLoop().schedule(() -> {
-			if (channel.isOpen()) {
-				startFlushTimer();
-				ackTick();
-			}
-		}, CONTROL_INTERVAL, TimeUnit.MILLISECONDS);
 	}
 
 	private void startResendTimer() {
@@ -88,8 +70,7 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 
 	protected void handleEncapsulatedData(ChannelHandlerContext ctx, RakNetEncapsulatedData packet) {
 		int packetSeqId = packet.getSeqId();
-		ackSet.add(packetSeqId);
-		nackSet.remove(packetSeqId);
+		ctx.writeAndFlush(new RakNetACK(packetSeqId)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
 		if (!idWithinWindow(packetSeqId) || handledSet.contains(packetSeqId)) { //ignore duplicate packet
 			return;
 		}
@@ -98,7 +79,7 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 			lastReceivedSeqId = UINT.B3.plus(lastReceivedSeqId, 1);
 			while (lastReceivedSeqId != packetSeqId) { //nack any missed packets before this one
 				if (!handledSet.contains(lastReceivedSeqId)) {
-					nackSet.add(lastReceivedSeqId); //add missing packets to nack set
+					ctx.writeAndFlush(new RakNetNACK(lastReceivedSeqId)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
 				}
 				lastReceivedSeqId = UINT.B3.plus(lastReceivedSeqId, 1);
 			}
@@ -165,19 +146,6 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 			channel.writeAndFlush(packet, promise);
 		} else {
 			channel.writeAndFlush(packet).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-		}
-	}
-
-	protected void ackTick() {
-		nackSet.removeIf(removalPredicate);
-		handledSet.removeIf(removalPredicate);
-		if (!ackSet.isEmpty()) {
-			channel.writeAndFlush(new RakNetACK(ackSet)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-			ackSet.clear();
-		}
-		if (!nackSet.isEmpty()) {
-			channel.writeAndFlush(new RakNetNACK(nackSet)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-			nackSet.clear();
 		}
 	}
 

--- a/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
+++ b/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
@@ -3,6 +3,8 @@ package raknetserver.pipeline.raknet;
 import io.netty.channel.*;
 import io.netty.handler.codec.DecoderException;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
 import raknetserver.packet.EncapsulatedPacket;
 import raknetserver.packet.raknet.RakNetEncapsulatedData;
 import raknetserver.packet.raknet.RakNetPacket;
@@ -12,8 +14,6 @@ import raknetserver.packet.raknet.RakNetReliability.RakNetNACK;
 import raknetserver.utils.Constants;
 import raknetserver.utils.PacketHandlerRegistry;
 import raknetserver.utils.UINT;
-
-import java.util.concurrent.TimeUnit;
 
 public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 
@@ -34,13 +34,16 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 	}
 
 	protected static final int HALF_WINDOW = UINT.B3.MAX_VALUE / 2;
+	protected static final int CONTROL_INTERVAL = 50; //millis
+	protected static final int ACK_REPEAT = 5;
 
-	protected final Int2ObjectOpenHashMap<Object> nackMap = new Int2ObjectOpenHashMap<>();
-	protected final Int2ObjectOpenHashMap<Object> ackMap = new Int2ObjectOpenHashMap<>();
-	protected final Int2ObjectOpenHashMap<RakNetEncapsulatedData> recvWindow = new Int2ObjectOpenHashMap<>();
-	protected final Int2ObjectOpenHashMap<RakNetEncapsulatedData> sentPackets = new Int2ObjectOpenHashMap	<>();
+	protected final IntSortedSet nackSet = new IntRBTreeSet();
+	protected final IntSortedSet ackSet = new IntRBTreeSet();
+	protected final Int2ObjectOpenHashMap<RakNetEncapsulatedData> recvStash = new Int2ObjectOpenHashMap<>();
+	protected final Int2ObjectOpenHashMap<RakNetEncapsulatedData> sentPackets = new Int2ObjectOpenHashMap<>();
 	protected int lastReceivedSeqId = -1;
 	protected long lastFlush = 0l;
+	protected int nextSendSeqId = 0;
 
 	protected void processEncapsulatedData(ChannelHandlerContext ctx, RakNetEncapsulatedData packet) {
 		int packetSeqId = packet.getSeqId();
@@ -48,38 +51,41 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 		lastReceivedSeqId = packetSeqId;
 		//read encapsulated packets
 		packet.getPackets().forEach(ctx::fireChannelRead);
-		recvWindow.remove(packetSeqId);
+		recvStash.remove(packetSeqId);
+		for (int i = 0 ; i < ACK_REPEAT ; i++) {
+			// lets be kind and repeat our acks a few times,
+			// the client resend buffer will thank us.
+			ackSet.add(UINT.B3.minus(packetSeqId, i + 1));
+		}
 	}
 
 	protected void handleEncapsulatedData(ChannelHandlerContext ctx, RakNetEncapsulatedData packet) {
 		int packetSeqId = packet.getSeqId();
 		int seqIdDiff = UINT.B3.minus(packetSeqId, lastReceivedSeqId);
 		//ignore duplicate packet
-		if (seqIdDiff <= 0) { // can be negative?
+		if (seqIdDiff == 0 || seqIdDiff > HALF_WINDOW) {
 			return;
 		}
-		if (seqIdDiff > HALF_WINDOW) {
+		if (seqIdDiff > Constants.MAX_PACKET_LOSS) {
 			throw new DecoderException("Too big packet loss from client");
 		}
-
-		ackMap.put(packetSeqId, null);
-		nackMap.remove(packetSeqId);
-
+		ackSet.add(packetSeqId);
+		nackSet.remove(packetSeqId);
 		//packet not needed yet
 		if (seqIdDiff > 1) {
 			// check missing id range and add to nack map
 			for (int i = 1 ; i < seqIdDiff ; i++) {
 				int nextId = UINT.B3.plus(lastReceivedSeqId, i);
-				if (!recvWindow.containsKey(nextId))
-					nackMap.put(nextId, null);
+				if (!recvStash.containsKey(nextId))
+					nackSet.add(nextId);
 			}
-			recvWindow.put(packetSeqId, packet);
+			recvStash.put(packetSeqId, packet);
 		} else {
 			//packet needed now
 			processEncapsulatedData(ctx, packet);
 			//restore any cached sequence available
-			for (int nextId = UINT.B3.plus(packetSeqId, 1); recvWindow.containsKey(nextId); nextId = UINT.B3.plus(nextId, 1)) {
-				processEncapsulatedData(ctx, recvWindow.get(nextId));
+			for (int nextId = UINT.B3.plus(packetSeqId, 1); recvStash.containsKey(nextId); nextId = UINT.B3.plus(nextId, 1)) {
+				processEncapsulatedData(ctx, recvStash.get(nextId));
 			}
 		}
 		flushControlResponses(ctx);
@@ -97,6 +103,7 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 				sentPackets.remove(UINT.B3.plus(idStart, i));
 			}
 		}
+		flushControlResponses(ctx);
 	}
 
 	protected void handleNack(ChannelHandlerContext ctx, RakNetNACK nack) {
@@ -114,24 +121,25 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 				}
 			}
 		}
+		flushControlResponses(ctx);
 	}
 
 	protected void flushControlResponses(ChannelHandlerContext ctx) {
-		long d = System.currentTimeMillis() - lastFlush;
-		if (d < 100) return;
-
+		long dt = System.currentTimeMillis() - lastFlush;
+		if (dt < CONTROL_INTERVAL) {
+			// we have these nice dense nack/ack packets, lets be kind towards
+			// the MTU, and slam the client with less small packets
+			return;
+		}
 		lastFlush = System.currentTimeMillis();
-
-		//TODO: should use the condensed version of the nack/ack when possible
-		for(int packetId : nackMap.keySet()) {
-			ctx.write(new RakNetNACK(packetId)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+		if (!nackSet.isEmpty()) {
+			ctx.writeAndFlush(new RakNetNACK(nackSet)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+			nackSet.clear();
 		}
-		for(int packetId : ackMap.keySet()) {
-			ctx.write(new RakNetACK(packetId)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+		if (!ackSet.isEmpty()) {
+			ctx.writeAndFlush(new RakNetACK(ackSet)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+			ackSet.clear();
 		}
-		nackMap.clear();
-		ackMap.clear();
-		ctx.flush();
 	}
 
 	@Override
@@ -146,7 +154,6 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 		}
 	}
 
-	protected int nextSendSeqId = 0;
 	protected void sendPacket(ChannelHandlerContext ctx, RakNetEncapsulatedData packet, ChannelPromise promise) {
 		int seqId = nextSendSeqId;
 		nextSendSeqId = UINT.B3.plus(nextSendSeqId, 1);

--- a/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
+++ b/src/raknetserver/pipeline/raknet/RakNetPacketReliabilityHandler.java
@@ -4,10 +4,13 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.DecoderException;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ByteOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
 import it.unimi.dsi.fastutil.ints.IntSortedSet;
+import it.unimi.dsi.fastutil.ints.IntComparators;
 import raknetserver.packet.EncapsulatedPacket;
 import raknetserver.packet.raknet.RakNetEncapsulatedData;
 import raknetserver.packet.raknet.RakNetPacket;
@@ -18,6 +21,9 @@ import raknetserver.utils.Constants;
 import raknetserver.utils.PacketHandlerRegistry;
 import raknetserver.utils.UINT;
 
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntPredicate;
+
 public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 
 	protected static final PacketHandlerRegistry<RakNetPacketReliabilityHandler, RakNetPacket> registry = new PacketHandlerRegistry<>();
@@ -27,8 +33,49 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 		registry.register(RakNetNACK.class, (ctx, handler, packet) -> handler.handleNack(ctx, packet));
 	}
 
+	protected static final int WINDOW = 4096;
+	protected static final int HALF_WINDOW = WINDOW / 2;
+	protected static final int CONTROL_INTERVAL = 50; //millis
+	protected static final int RETRY_TICK_MULTIPLIER = 2; //resend window starts at 100-150ms
+	protected static final byte[] FIBONACCI = new byte[] { 1, 1, 2, 3, 5, 8, 13, 21, 34 }; //used for retry backoff
+
+	protected final IntSortedSet nackSet = new IntRBTreeSet(IntComparators.NATURAL_COMPARATOR);
+	protected final IntSortedSet ackSet = new IntRBTreeSet(IntComparators.NATURAL_COMPARATOR);
+	protected final IntSortedSet handledSet = new IntRBTreeSet(IntComparators.NATURAL_COMPARATOR);
+	protected final Int2ByteOpenHashMap sentPacketResendTicks = new Int2ByteOpenHashMap();
+	protected final Int2ByteOpenHashMap sentPacketResendAttempts = new Int2ByteOpenHashMap();
+	protected final Int2ObjectOpenHashMap<RakNetEncapsulatedData> sentPackets = new Int2ObjectOpenHashMap<>();
+	protected final IntPredicate removalPredicate = x -> !idWithinWindow(x);
+	protected int lastReceivedSeqId = 0;
+	protected int nextSendSeqId = 0;
+
+	// metrics
+	protected long duplicatesReceived = 0;
+	protected long timedResends = 0;
+	protected long nackResends = 0;
+	protected long nacksSent = 0;
+	protected long flushesDone = 0;
+
+	protected final Channel channel;
+
+	public RakNetPacketReliabilityHandler(Channel channel) {
+		this.channel = channel;
+		startFlushTimer();
+		sentPacketResendTicks.defaultReturnValue((byte)0);
+		sentPacketResendAttempts.defaultReturnValue((byte)0);
+	}
+
+	private void startFlushTimer() {
+		channel.eventLoop().schedule(() -> {
+			if (channel.isOpen()) {
+				flushControlResponses();
+				startFlushTimer();
+			}
+		}, CONTROL_INTERVAL, TimeUnit.MILLISECONDS);
+	}
+
 	@Override
-	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+	public void channelRead(ChannelHandlerContext ctx, Object msg) {
 		if (msg instanceof RakNetPacket) {
 			registry.handle(ctx, this, (RakNetPacket) msg);
 		} else {
@@ -36,112 +83,66 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 		}
 	}
 
-	protected static final int HALF_WINDOW = UINT.B3.MAX_VALUE / 2;
-	protected static final int CONTROL_INTERVAL = 50; //millis
-	protected static final int ACK_REPEAT = 5;
-
-	protected final IntSortedSet nackSet = new IntRBTreeSet();
-	protected final IntSortedSet ackSet = new IntRBTreeSet();
-	protected final Int2ObjectOpenHashMap<RakNetEncapsulatedData> recvStash = new Int2ObjectOpenHashMap<>();
-	protected final Int2ObjectOpenHashMap<RakNetEncapsulatedData> sentPackets = new Int2ObjectOpenHashMap<>();
-	protected int lastReceivedSeqId = -1;
-	protected long lastFlush = 0l;
-	protected int nextSendSeqId = 0;
-
-	protected void processEncapsulatedData(ChannelHandlerContext ctx, RakNetEncapsulatedData packet) {
-		int packetSeqId = packet.getSeqId();
-		//can now update last received seq id
-		lastReceivedSeqId = packetSeqId;
-		//read encapsulated packets
-		packet.getPackets().forEach(ctx::fireChannelRead);
-		recvStash.remove(packetSeqId);
-		for (int i = 0 ; i < ACK_REPEAT ; i++) {
-			//lets be kind and repeat our acks a few times,
-			//the client resend buffer will thank us.
-			ackSet.add(UINT.B3.minus(packetSeqId, i + 1));
-		}
+	protected boolean idWithinWindow(int id) {
+		return Math.abs(UINT.B3.minusWrap(id, lastReceivedSeqId)) < HALF_WINDOW;
 	}
 
 	protected void handleEncapsulatedData(ChannelHandlerContext ctx, RakNetEncapsulatedData packet) {
 		int packetSeqId = packet.getSeqId();
-		int seqIdDiff = UINT.B3.minus(packetSeqId, lastReceivedSeqId);
-		//ignore duplicate packet
-		if (seqIdDiff == 0 || seqIdDiff > HALF_WINDOW) {
-			return;
-		}
-		if (seqIdDiff > Constants.MAX_PACKET_LOSS) {
-			throw new DecoderException("Too big packet loss from client");
-		}
 		ackSet.add(packetSeqId);
 		nackSet.remove(packetSeqId);
-		if (seqIdDiff > 1) { //packet not needed yet
-			//check missing id range and add to nack map
-			for (int i = 1 ; i < seqIdDiff ; i++) {
-				int nextId = UINT.B3.plus(lastReceivedSeqId, i);
-				if (!recvStash.containsKey(nextId)) {
-					nackSet.add(nextId);
+		if (!idWithinWindow(packetSeqId) || handledSet.contains(packetSeqId)) { //ignore duplicate packet
+			duplicatesReceived++;
+			return;
+		}
+		handledSet.add(packetSeqId);
+		if (UINT.B3.minusWrap(packetSeqId, lastReceivedSeqId) > 0) { //can be zero on the first packet only
+			lastReceivedSeqId = UINT.B3.plus(lastReceivedSeqId, 1);
+			while (lastReceivedSeqId != packetSeqId) {
+				//add missing packets to nack
+				if (!handledSet.contains(lastReceivedSeqId)) {
+					nackSet.add(lastReceivedSeqId);
 				}
-			}
-			recvStash.put(packetSeqId, packet);
-		} else { //packet needed now
-			processEncapsulatedData(ctx, packet);
-			//restore any cached sequence available
-			for (int nextId = UINT.B3.plus(packetSeqId, 1); recvStash.containsKey(nextId); nextId = UINT.B3.plus(nextId, 1)) {
-				processEncapsulatedData(ctx, recvStash.get(nextId));
+				lastReceivedSeqId = UINT.B3.plus(lastReceivedSeqId, 1);
 			}
 		}
-		flushControlResponses(ctx);
+		//read encapsulated packets
+		packet.getPackets().forEach(ctx::fireChannelRead);
 	}
 
 	protected void handleAck(ChannelHandlerContext ctx, RakNetACK ack) {
 		for (REntry entry : ack.getEntries()) {
 			int idStart = entry.idStart;
 			int idFinish = entry.idFinish;
-			int idDiff = UINT.B3.minus(idFinish, idStart);
+			int idDiff = UINT.B3.minusWrap(idFinish, idStart);
 			if (idDiff > Constants.MAX_PACKET_LOSS) {
 				throw new DecoderException("Too big packet loss (ack confirm range)");
 			}
 			for (int i = 0; i <= idDiff; i++) {
-				sentPackets.remove(UINT.B3.plus(idStart, i));
+				int packetId = UINT.B3.plus(idStart, i);
+				sentPackets.remove(packetId);
+				sentPacketResendTicks.remove(packetId);
+				sentPacketResendAttempts.remove(packetId);
 			}
 		}
-		flushControlResponses(ctx);
 	}
 
 	protected void handleNack(ChannelHandlerContext ctx, RakNetNACK nack) {
 		for (REntry entry : nack.getEntries()) {
 			int idStart = entry.idStart;
 			int idFinish = entry.idFinish;
-			int idDiff = UINT.B3.minus(idFinish, idStart);
+			int idDiff = UINT.B3.minusWrap(idFinish, idStart);
 			if (idDiff > Constants.MAX_PACKET_LOSS) {
 				throw new DecoderException("Too big packet loss (nack resend range)");
 			}
 			for (int i = 0; i <= idDiff; i++) {
 				RakNetEncapsulatedData packet = sentPackets.remove(UINT.B3.plus(idStart, i));
 				if (packet != null) {
-					sendPacket(ctx, packet, null);
+					sendPacket(packet, null);
+					nackResends++;
 				}
 			}
 		}
-		flushControlResponses(ctx);
-	}
-
-	protected void flushControlResponses(ChannelHandlerContext ctx) {
-		long dt = System.currentTimeMillis() - lastFlush;
-		if (dt < CONTROL_INTERVAL) {
-			//we have these nice dense nack/ack packets, lets be kind towards
-			//the MTU, and slam the client with less small packets
-			return;
-		}
-		if (!nackSet.isEmpty()) {
-			ctx.writeAndFlush(new RakNetNACK(nackSet)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-			nackSet.clear();
-		}
-		if (!ackSet.isEmpty()) {
-			ctx.writeAndFlush(new RakNetACK(ackSet)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-			ackSet.clear();
-		}
-		lastFlush = System.currentTimeMillis();
 	}
 
 	@Override
@@ -150,22 +151,57 @@ public class RakNetPacketReliabilityHandler extends ChannelDuplexHandler {
 			if (sentPackets.size() > Constants.MAX_PACKET_LOSS) {
 				throw new DecoderException("Too big packet loss (unconfirmed sent packets)");
 			}
-			sendPacket(ctx, new RakNetEncapsulatedData((EncapsulatedPacket) msg), promise);
+			RakNetEncapsulatedData outPacket = new RakNetEncapsulatedData((EncapsulatedPacket) msg);
+			outPacket.setSeqId(nextSendSeqId);
+			nextSendSeqId = UINT.B3.plus(nextSendSeqId, 1);
+			sendPacket(outPacket, promise);
 		} else {
 			ctx.writeAndFlush(msg, promise);
 		}
 	}
 
-	protected void sendPacket(ChannelHandlerContext ctx, RakNetEncapsulatedData packet, ChannelPromise promise) {
-		int seqId = nextSendSeqId;
-		nextSendSeqId = UINT.B3.plus(nextSendSeqId, 1);
-		packet.setSeqId(seqId);
+	protected void sendPacket(RakNetEncapsulatedData packet, ChannelPromise promise) {
+		int attempts = sentPacketResendAttempts.get(packet.getSeqId());
+		int resendTicks = RETRY_TICK_MULTIPLIER * FIBONACCI[Math.min(attempts, FIBONACCI.length - 1)];
 		sentPackets.put(packet.getSeqId(), packet);
+		sentPacketResendTicks.put(packet.getSeqId(), (byte)resendTicks);
+		sentPacketResendAttempts.put(packet.getSeqId(), (byte)(attempts + 1));
 		if (promise != null) {
-			ctx.writeAndFlush(packet, promise);
+			channel.writeAndFlush(packet, promise);
 		} else {
-			ctx.writeAndFlush(packet).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+			channel.writeAndFlush(packet).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
 		}
 	}
 
+	//pool ACKs/NACKs and flush on a tick
+	protected void flushControlResponses() {
+		flushesDone++;
+		nackSet.removeIf(removalPredicate);
+		handledSet.removeIf(removalPredicate);
+		if (!ackSet.isEmpty()) {
+			channel.writeAndFlush(new RakNetACK(ackSet)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+			ackSet.clear();
+		}
+		if (!nackSet.isEmpty()) {
+			channel.writeAndFlush(new RakNetNACK(nackSet)).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+			nacksSent += nackSet.size();
+			nackSet.clear();
+		}
+		//resend packets when needed
+		for (int sentId : sentPacketResendTicks.keySet()) {
+			int ticks = sentPacketResendTicks.get(sentId);
+			if (ticks == 0) {
+				sendPacket(sentPackets.get(sentId), null); //resend packet, and mark new time
+				timedResends++;
+			} else {
+				sentPacketResendTicks.put(sentId, (byte)(ticks - 1));
+			}
+		}
+		//TODO: expose this somewhere
+		if ((flushesDone % 100) == 0 && lastReceivedSeqId > 2) {
+			System.out.println(String.format(
+					"RakNet: duplicatesReceived: %d, nackResends: %d, timedResends: %d, nacksSent: %d",
+					duplicatesReceived, nackResends, timedResends, nacksSent));
+		}
+	}
 }

--- a/src/raknetserver/utils/UINT.java
+++ b/src/raknetserver/utils/UINT.java
@@ -33,8 +33,11 @@ public class UINT {
 			final int dist = value - minus;
 			if (dist < 0) {
 				return -minusWrap(minus, value);
+			} else if (dist > HALF_MAX) {
+				return value - (minus + MAX_VALUE + 1);
+			} else {
+				return dist;
 			}
-			return dist > HALF_MAX ? value - (minus + MAX_VALUE + 1) : dist;
 		}
 	}
 

--- a/src/raknetserver/utils/UINT.java
+++ b/src/raknetserver/utils/UINT.java
@@ -18,8 +18,7 @@ public class UINT {
 
 	public static class B3 {
 
-		public static final int ADD_MASK = 1 << (Byte.SIZE * 3);
-		public static final int MAX_VALUE = ADD_MASK - 1;
+		public static final int MAX_VALUE = (1 << (Byte.SIZE * 3)) - 1;
 		public static final int HALF_MAX = MAX_VALUE / 2;
 
 		public static int plus(int value, int add) {
@@ -36,26 +35,8 @@ public class UINT {
 			} else if (minus > value) {
 				return -minusWrap(minus, value);
 			}
-			assert minus < value;
-			int dist = value - minus;
-			if (dist > HALF_MAX) {
-				return value - (minus | ADD_MASK);
-			}
-
-			return dist;
-		}
-
-		static {
-			for(int i = 0 ; i < 100000 ; i++) {
-				int a = (int)(Math.random() * MAX_VALUE);
-				int d = (int)(Math.random() * MAX_VALUE) - HALF_MAX;
-				int b = plus(a, d);
-
-				if(minusWrap(b, a) != d)
-					System.err.println(String.format("self test failed for (%d, %d) expected %d got %d", a, b, d, minusWrap(a, b)));
-			}
-
-			System.err.println("self test done");
+			final int dist = value - minus;
+			return dist > HALF_MAX ? value - (minus + MAX_VALUE + 1) : dist;
 		}
 	}
 

--- a/src/raknetserver/utils/UINT.java
+++ b/src/raknetserver/utils/UINT.java
@@ -30,12 +30,10 @@ public class UINT {
 		}
 
 		public static int minusWrap(int value, int minus) {
-			if (minus == value) {
-				return 0;
-			} else if (minus > value) {
+			final int dist = value - minus;
+			if (dist < 0) {
 				return -minusWrap(minus, value);
 			}
-			final int dist = value - minus;
 			return dist > HALF_MAX ? value - (minus + MAX_VALUE + 1) : dist;
 		}
 	}

--- a/src/raknetserver/utils/UINT.java
+++ b/src/raknetserver/utils/UINT.java
@@ -18,7 +18,9 @@ public class UINT {
 
 	public static class B3 {
 
-		public static final int MAX_VALUE = ((1 << (Byte.SIZE * 3)) - 1);
+		public static final int ADD_MASK = 1 << (Byte.SIZE * 3);
+		public static final int MAX_VALUE = ADD_MASK - 1;
+		public static final int HALF_MAX = MAX_VALUE / 2;
 
 		public static int plus(int value, int add) {
 			return (value + add) & MAX_VALUE;
@@ -28,6 +30,33 @@ public class UINT {
 			return (value - minus) & MAX_VALUE;
 		}
 
+		public static int minusWrap(int value, int minus) {
+			if (minus == value) {
+				return 0;
+			} else if (minus > value) {
+				return -minusWrap(minus, value);
+			}
+			assert minus < value;
+			int dist = value - minus;
+			if (dist > HALF_MAX) {
+				return value - (minus | ADD_MASK);
+			}
+
+			return dist;
+		}
+
+		static {
+			for(int i = 0 ; i < 100000 ; i++) {
+				int a = (int)(Math.random() * MAX_VALUE);
+				int d = (int)(Math.random() * MAX_VALUE) - HALF_MAX;
+				int b = plus(a, d);
+
+				if(minusWrap(b, a) != d)
+					System.err.println(String.format("self test failed for (%d, %d) expected %d got %d", a, b, d, minusWrap(a, b)));
+			}
+
+			System.err.println("self test done");
+		}
 	}
 
 }

--- a/test/raknetserver/utils/UINTTests.java
+++ b/test/raknetserver/utils/UINTTests.java
@@ -1,0 +1,39 @@
+package raknetserver.utils;
+
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.*;
+import static raknetserver.utils.UINT.B3.*;
+
+public class UINTTests {
+    @Test
+    public void testMinusWrap() {
+        Random random = new Random(0);
+        for(int i = 0 ; i < 1000000 ; i++) {
+            int a = (int)(random.nextDouble() * MAX_VALUE);
+            int d = (int)(random.nextDouble() * MAX_VALUE) - HALF_MAX;
+            int b = plus(a, d);
+
+            assertEquals(minusWrap(b, a), d);
+        }
+    }
+
+    @Test
+    public void testMinusFail() {
+        Random random = new Random(0);
+        boolean hasFailed = false;
+        for(int i = 0 ; i < 1000000 ; i++) {
+            int a = (int)(random.nextDouble() * MAX_VALUE);
+            int d = (int)(random.nextDouble() * MAX_VALUE) - HALF_MAX;
+            int b = plus(a, d);
+
+            if (minus(b, a) != d) {
+                hasFailed = true;
+            }
+        }
+
+        assertTrue(hasFailed);
+    }
+}


### PR DESCRIPTION
* Implement new dense form of NACK and ACK
* ~~Use this new form to be much more pessimistic about sending NACKs and ACKs.~~
  * ~~Send NACKs for *each* missing packet *every* time we get a new out-of-order packet.~~
  * ~~Repeat ACKs a few times for each subsequent handled packet.~~
* Back to optimistic NACK/ACK! Because that's not the job of this part of RakNet.
  * NACK is a formality- its just a request for a resend of data that was going to be resent anyways, eventually. 
  * The client will resend us important stuff until we ACK the packet that contained it (and the server should do the same). 
  * It might ignore our NACKs if the packet didn't contain anything important (this took a while to figure out). 
* Doing what I can to reduce allocations.
* Rewrote ordering queue. 
* Fixed the 24-bit wrapping logic when comparing difference
* Scheduled resends on an RTT interval tick, with backoff